### PR TITLE
Fix to ore counts (suggested)

### DIFF
--- a/dimensions/overworld.json
+++ b/dimensions/overworld.json
@@ -463,14 +463,14 @@
             "maxPerChunk": 2,
             "maxHeight": 18,
             "minPerChunk": 1,
-            "minSize": 2,
-            "maxSize": 5,
+            "minSize": 1,
+            "maxSize": 6,
             "palette": [
                 {
                     "block": "diamond_ore"
                 }
             ],
-            "varience": 4
+            "varience": 6
         },
         {
             "minHeight": 4,
@@ -491,25 +491,25 @@
         },
         {
             "minHeight": 3,
-            "maxPerChunk": 2,
+            "maxPerChunk": 3,
             "maxHeight": 67,
             "minPerChunk": 1,
-            "minSize": 1,
-            "maxSize": 3,
+            "minSize": 3,
+            "maxSize": 6,
             "palette": [
                 {
                     "block": "gold_ore"
                 }
             ],
-            "varience": 3
+            "varience": 5
         },
         {
             "minHeight": 3,
-            "maxPerChunk": 1,
+            "maxPerChunk": 2,
             "maxHeight": 29,
-            "minPerChunk": 0,
+            "minPerChunk": 1,
             "minSize": 3,
-            "maxSize": 8,
+            "maxSize": 7,
             "palette": [
                 {
                     "block": "lapis_ore"
@@ -519,9 +519,9 @@
         },
         {
             "minHeight": 1,
-            "maxPerChunk": 9,
+            "maxPerChunk": 25,
             "maxHeight": 120,
-            "minPerChunk": 9,
+            "minPerChunk": 15,
             "minSize": 3,
             "maxSize": 8,
             "palette": [
@@ -529,15 +529,15 @@
                     "block": "iron_ore"
                 }
             ],
-            "varience": 7
+            "varience": 8
         },
         {
             "minHeight": 1,
-            "maxPerChunk": 10,
+            "maxPerChunk": 35,
             "maxHeight": 175,
-            "minPerChunk": 9,
-            "minSize": 6,
-            "maxSize": 10,
+            "minPerChunk": 20,
+            "minSize": 7,
+            "maxSize": 16,
             "palette": [
                 {
                     "block": "coal_ore"


### PR DESCRIPTION
89.47368421	dia
87.87878788	lapiz
67.12328767	gold
39.08045977	redst
43.76996805	iron
55.13924051	coal
Percentages    Ore
Vanilla-iris