### PR TITLE
Patches "Can't find jigsaw pool: <blank>"

### DIFF
--- a/jigsaw-pieces/stronghold/room/witch-room-end.json
+++ b/jigsaw-pieces/stronghold/room/witch-room-end.json
@@ -6,7 +6,7 @@
             "entityCount": 1,
             "rotateConnector": false,
             "name": "",
-            "pools": [""],
+            "pools": [],
             "position": {
                 "x": 0,
                 "y": -3,


### PR DESCRIPTION
You may have noticed Iris has lately started saying "Cannot find jigsaw pool: " in every time it compiles the overworld pack. This is the reason, and the patch resolves it. The proper way to indicate an empty pool is `"pools": []`