### PR TITLE
Temperate/Tundra Entity Changes

### DIFF
--- a/biomes/temperate/birch-denmyre.json
+++ b/biomes/temperate/birch-denmyre.json
@@ -210,12 +210,20 @@
             }
         }
     ],
-    "entityInitialSpawns": [{
-        "entity": "bee",
-        "maxSpawns": 5,
-        "minSpawns": 2,
-        "rarity": 3
-    }],
+    "entityInitialSpawns": [
+        {
+            "entity": "bee",
+            "maxSpawns": 5,
+            "minSpawns": 2,
+            "rarity": 3
+        },
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        }
+    ],
     "wall": {
         "style": {"style": "STATIC"},
         "palette": [

--- a/biomes/temperate/birch-forest.json
+++ b/biomes/temperate/birch-forest.json
@@ -200,5 +200,25 @@
             {"block": "andesite"},
             {"block": "stone"}
         ]
-    }
+    },
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 90
+        },
+        {
+            "entity": "goat",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 70
+        }
+    ]
 }

--- a/biomes/temperate/birch-thin.json
+++ b/biomes/temperate/birch-thin.json
@@ -172,5 +172,25 @@
             {"block": "andesite"},
             {"block": "stone"}
         ]
-    }
+    },
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 80
+        },
+        {
+            "entity": "goat",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 90
+        }
+    ]
 }

--- a/biomes/temperate/combo-forest.json
+++ b/biomes/temperate/combo-forest.json
@@ -35,6 +35,7 @@
             ]
         }
     ],
+
     "jigsawStructures": [
         {
             "rarity": 1700,
@@ -45,30 +46,69 @@
             "structure": "village-temperate"
         }
     ],
-    "entityInitialSpawns": [
+    "biomeStyle": {"style": "SIMPLEX"},
+    "decorators": [
         {
-            "entity": "cow",
-            "maxSpawns": 1,
-            "minSpawns": 1,
-            "rarity": 7
+            "chance": 0.8,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [
+                {
+                    "weight": 1,
+                    "block": "grass"
+                },
+                {"block": "grass"},
+                {"block": "grass"},
+                {
+                    "chance": 7,
+                    "block": "grass"
+                }
+            ]
         },
         {
-            "entity": "pig",
-            "maxSpawns": 1,
-            "minSpawns": 1,
-            "rarity": 7
+            "chance": 0.03,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [{
+                "block": "oak_leaves",
+                "data": {"persistent": true}
+            }]
         },
         {
-            "entity": "chicken",
-            "maxSpawns": 1,
-            "minSpawns": 1,
-            "rarity": 7
+            "chance": 0.02,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [{"block": "tall_grass"}]
         },
         {
-            "entity": "sheep",
-            "maxSpawns": 1,
-            "minSpawns": 1,
-            "rarity": 7
+            "chance": 0.03,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [{"block": "rose_bush"}]
+        },
+        {
+            "chance": 0.05,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [{
+                "chance": 3,
+                "block": "red_mushroom"
+            }]
+        },
+        {
+            "chance": 0.05,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [{
+                "chance": 3,
+                "block": "poppy"
+            }]
+        },
+        {
+            "chance": 0.03,
+            "variance": {"style": "STATIC"},
+            "zoom": 0.2,
+            "palette": [{"block": "cobblestone_slab"}]
         }
     ],
     "objects": [
@@ -250,71 +290,6 @@
             ]
         }
     ],
-    "biomeStyle": {"style": "SIMPLEX"},
-    "decorators": [
-        {
-            "chance": 0.8,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [
-                {
-                    "weight": 1,
-                    "block": "grass"
-                },
-                {"block": "grass"},
-                {"block": "grass"},
-                {
-                    "chance": 7,
-                    "block": "grass"
-                }
-            ]
-        },
-        {
-            "chance": 0.03,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [{
-                "block": "oak_leaves",
-                "data": {"persistent": true}
-            }]
-        },
-        {
-            "chance": 0.02,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [{"block": "tall_grass"}]
-        },
-        {
-            "chance": 0.03,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [{"block": "rose_bush"}]
-        },
-        {
-            "chance": 0.05,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [{
-                "chance": 3,
-                "block": "red_mushroom"
-            }]
-        },
-        {
-            "chance": 0.05,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [{
-                "chance": 3,
-                "block": "poppy"
-            }]
-        },
-        {
-            "chance": 0.03,
-            "variance": {"style": "STATIC"},
-            "zoom": 0.2,
-            "palette": [{"block": "cobblestone_slab"}]
-        }
-    ],
     "wall": {
         "style": {"style": "STATIC"},
         "palette": [
@@ -323,5 +298,25 @@
             {"block": "stone"}
         ]
     },
-    "biomeScatter": ["FOREST"]
+    "biomeScatter": ["FOREST"],
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 70
+        }
+    ]
 }

--- a/biomes/temperate/flower-forest.json
+++ b/biomes/temperate/flower-forest.json
@@ -65,7 +65,12 @@
         "entity": "bee",
         "maxSpawns": 5,
         "minSpawns": 2,
-        "rarity": 3
+        "rarity": 20
+    }, {
+        "entity": "sheep",
+        "maxSpawns": 2,
+        "minSpawns": 1,
+        "rarity": 10
     }],
     "objects": [
         {

--- a/biomes/temperate/highlands.json
+++ b/biomes/temperate/highlands.json
@@ -55,12 +55,20 @@
             ]
         }
     ],
-    "entityInitialSpawns": [{
-        "entity": "bee",
-        "maxSpawns": 5,
-        "minSpawns": 2,
-        "rarity": 3
-    }],
+    "entityInitialSpawns": [
+        {
+            "entity": "bee",
+            "maxSpawns": 5,
+            "minSpawns": 2,
+            "rarity": 3
+        },
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        }
+    ],
     "decorators": [
         {
             "chance": 0.003,

--- a/biomes/temperate/island.json
+++ b/biomes/temperate/island.json
@@ -115,7 +115,6 @@
             ]
         }
     ],
-    "biomeZoom": 60,
     "biomeStyle": {"style": "SIMPLEX"},
     "wall": {
         "style": {"style": "STATIC"},
@@ -128,5 +127,13 @@
     "biomeScatter": [
         "FOREST",
         "PLAINS"
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        }
     ]
 }

--- a/biomes/temperate/longtree-forest.json
+++ b/biomes/temperate/longtree-forest.json
@@ -381,5 +381,19 @@
             }
         ],
         "style": {"style": "STATIC"}
-    }
+    },
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 70
+        }
+    ]
 }

--- a/biomes/temperate/lush-plains-red.json
+++ b/biomes/temperate/lush-plains-red.json
@@ -197,5 +197,19 @@
     "wall": {"palette": [
         {"block": "stone"},
         {"block": "andesite"}
-    ]}
+    ]},
+    "entityInitialSpawns": [
+        {
+            "entity": "horse",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 80
+        },
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        }
+    ]
 }

--- a/biomes/temperate/lush-plains-yellow.json
+++ b/biomes/temperate/lush-plains-yellow.json
@@ -197,5 +197,19 @@
     "wall": {"palette": [
         {"block": "stone"},
         {"block": "andesite"}
-    ]}
+    ]},
+    "entityInitialSpawns": [
+        {
+            "entity": "horse",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 80
+        },
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        }
+    ]
 }

--- a/biomes/temperate/lush-plains.json
+++ b/biomes/temperate/lush-plains.json
@@ -225,5 +225,19 @@
     "wall": {"palette": [
         {"block": "stone"},
         {"block": "andesite"}
-    ]}
+    ]},
+    "entityInitialSpawns": [
+        {
+            "entity": "horse",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 80
+        },
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        }
+    ]
 }

--- a/biomes/temperate/meadows.json
+++ b/biomes/temperate/meadows.json
@@ -215,34 +215,16 @@
     ],
     "entityInitialSpawns": [
         {
-            "entity": "cow",
-            "maxSpawns": 3,
-            "minSpawns": 1,
-            "rarity": 7
-        },
-        {
-            "entity": "pig",
-            "maxSpawns": 3,
-            "minSpawns": 1,
-            "rarity": 7
-        },
-        {
-            "entity": "chicken",
-            "maxSpawns": 3,
-            "minSpawns": 1,
-            "rarity": 7
-        },
-        {
             "entity": "sheep",
             "maxSpawns": 3,
             "minSpawns": 1,
-            "rarity": 7
+            "rarity": 10
         },
         {
             "entity": "horse",
             "minSpawns": 2,
             "maxSpawns": 5,
-            "rarity": 120
+            "rarity": 80
         }
     ],
     "biomeStyle": {"style": "SIMPLEX"},

--- a/biomes/temperate/oak-denmyre.json
+++ b/biomes/temperate/oak-denmyre.json
@@ -199,5 +199,25 @@
             {"block": "andesite"},
             {"block": "stone"}
         ]
-    }
+    },
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 90
+        }
+    ]
 }

--- a/biomes/temperate/oak-forest.json
+++ b/biomes/temperate/oak-forest.json
@@ -220,5 +220,25 @@
                 "z": 0
             }
         }
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 90
+        }
     ]
 }

--- a/biomes/temperate/plains.json
+++ b/biomes/temperate/plains.json
@@ -292,7 +292,13 @@
             "entity": "horse",
             "minSpawns": 2,
             "maxSpawns": 5,
-            "rarity": 120
+            "rarity": 70
+        },
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
         }
     ],
     "biomeStyle": {"style": "SIMPLEX"},

--- a/biomes/temperate/plateau.json
+++ b/biomes/temperate/plateau.json
@@ -322,5 +322,24 @@
         ]
     },
     "biomeScatter": ["FOREST"],
-    "biomeZoom": 60
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "goat",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 90
+        }
+    ]
 }

--- a/biomes/temperate/sakura-pink-child.json
+++ b/biomes/temperate/sakura-pink-child.json
@@ -219,5 +219,25 @@
             {"block": "stone"}
         ]
     },
-    "biomeScatter": ["FOREST"]
+    "biomeScatter": ["FOREST"],
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 90
+        }
+    ]
 }

--- a/biomes/temperate/sakura-pink-forest.json
+++ b/biomes/temperate/sakura-pink-forest.json
@@ -47,12 +47,26 @@
             ]
         }
     ],
-    "entityInitialSpawns": [{
-        "entity": "bee",
-        "maxSpawns": 5,
-        "minSpawns": 2,
-        "rarity": 3
-    }],
+    "entityInitialSpawns": [
+        {
+            "entity": "sheep",
+            "minSpawns": 1,
+            "maxSpawns": 2,
+            "rarity": 10
+        },
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 90
+        }
+    ],
     "objects": [
         {
             "chance": 0.1,

--- a/biomes/temperate/stranged-plains.json
+++ b/biomes/temperate/stranged-plains.json
@@ -21,6 +21,31 @@
         "max": 10,
         "generator": "plain"
     }],
+    "layers": [
+        {"palette": [{"block": "grass_block"}]},
+        {
+            "minHeight": 2,
+            "maxHeight": 2,
+            "palette": [{"block": "dirt"}]
+        },
+        {
+            "minHeight": 1,
+            "maxHeight": 3,
+            "palette": [
+                {"block": "dirt"},
+                {"block": "coarse_dirt"}
+            ]
+        },
+        {
+            "minHeight": 6,
+            "maxHeight": 18,
+            "style": {"style": "STATIC"},
+            "palette": [
+                {"block": "dirt"},
+                {"block": "stone"}
+            ]
+        }
+    ],
     "decorators": [
         {
             "chance": 0.4,
@@ -178,31 +203,6 @@
                     "max": 360
                 }
             }
-        }
-    ],
-    "layers": [
-        {"palette": [{"block": "grass_block"}]},
-        {
-            "minHeight": 2,
-            "maxHeight": 2,
-            "palette": [{"block": "dirt"}]
-        },
-        {
-            "minHeight": 1,
-            "maxHeight": 3,
-            "palette": [
-                {"block": "dirt"},
-                {"block": "coarse_dirt"}
-            ]
-        },
-        {
-            "minHeight": 6,
-            "maxHeight": 18,
-            "style": {"style": "STATIC"},
-            "palette": [
-                {"block": "dirt"},
-                {"block": "stone"}
-            ]
         }
     ],
     "wall": {"palette": [

--- a/biomes/tundra/autumn.json
+++ b/biomes/tundra/autumn.json
@@ -468,5 +468,19 @@
             ],
             "mode": "VACUUM"
         }
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 1,
+            "maxSpawns": 3,
+            "rarity": 30
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 30
+        }
     ]
 }

--- a/biomes/tundra/forest.json
+++ b/biomes/tundra/forest.json
@@ -200,5 +200,19 @@
     "biomeScatter": [
         "TAIGA_HILLS",
         "MOUNTAINS"
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 1,
+            "maxSpawns": 3,
+            "rarity": 30
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 30
+        }
     ]
 }

--- a/biomes/tundra/mountains-cliffs.json
+++ b/biomes/tundra/mountains-cliffs.json
@@ -272,5 +272,25 @@
         "TAIGA_HILLS",
         "MOUNTAINS",
         "SWAMP"
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 1,
+            "maxSpawns": 5,
+            "rarity": 90
+        },
+        {
+            "entity": "goat",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 30
+        },
+        {
+            "entity": "llama",
+            "maxSpawns": 2,
+            "minSpawns": 5,
+            "rarity": 80
+        }
     ]
 }

--- a/biomes/tundra/mountains.json
+++ b/biomes/tundra/mountains.json
@@ -206,5 +206,25 @@
         "TAIGA_HILLS",
         "MOUNTAINS",
         "SWAMP"
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 70
+        },
+        {
+            "entity": "goat",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 30
+        },
+        {
+            "entity": "llama",
+            "maxSpawns": 2,
+            "minSpawns": 5,
+            "rarity": 80
+        }
     ]
 }

--- a/biomes/tundra/redwood-cliffs.json
+++ b/biomes/tundra/redwood-cliffs.json
@@ -411,5 +411,19 @@
             ],
             "mode": "VACUUM"
         }
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 2,
+            "maxSpawns": 5,
+            "rarity": 90
+        },
+        {
+            "entity": "goat",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 60
+        }
     ]
 }

--- a/biomes/tundra/redwood-forest.json
+++ b/biomes/tundra/redwood-forest.json
@@ -372,5 +372,19 @@
             ],
             "mode": "VACUUM"
         }
+    ],
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 1,
+            "maxSpawns": 3,
+            "rarity": 30
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 30
+        }
     ]
 }

--- a/biomes/tundra/sequia-redwoods.json
+++ b/biomes/tundra/sequia-redwoods.json
@@ -296,5 +296,19 @@
     "wall": {
         "style": {"style": "STATIC"},
         "palette": [{"block": "coarse_dirt"}]
-    }
+    },
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 1,
+            "maxSpawns": 3,
+            "rarity": 50
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 50
+        }
+    ]
 }

--- a/biomes/tundra/taiga.json
+++ b/biomes/tundra/taiga.json
@@ -282,5 +282,19 @@
             {"block": "andesite"},
             {"block": "stone"}
         ]
-    }
+    },
+    "entityInitialSpawns": [
+        {
+            "entity": "wolf",
+            "minSpawns": 1,
+            "maxSpawns": 3,
+            "rarity": 30
+        },
+        {
+            "entity": "fox",
+            "maxSpawns": 1,
+            "minSpawns": 3,
+            "rarity": 30
+        }
+    ]
 }

--- a/regions/temperate.json
+++ b/regions/temperate.json
@@ -30,65 +30,30 @@
         "structure": "murky_stronghold",
         "rarity": 750
     }],
+    "ENTITY_SPAWNS": "Sheep is purposely missing from this list so it doesn't spawn in estranged plains",
     "entityInitialSpawns": [
         {
             "entity": "chicken",
             "maxSpawns": 2,
             "minSpawns": 1,
-            "rarity": 14
+            "rarity": 10
         },
         {
             "entity": "cow",
             "maxSpawns": 2,
             "minSpawns": 1,
-            "rarity": 14
+            "rarity": 10
         },
         {
             "entity": "pig",
             "maxSpawns": 2,
             "minSpawns": 1,
-            "rarity": 14
-        },
-        {
-            "entity": "sheep",
-            "maxSpawns": 2,
-            "minSpawns": 1,
-            "rarity": 14
-        },
-        {
-            "entity": "wolf",
-            "maxSpawns": 2,
-            "minSpawns": 1,
-            "rarity": 18
-        },
-        {
-            "entity": "goat",
-            "maxSpawns": 2,
-            "minSpawns": 1,
-            "rarity": 38
-        },
-        {
-            "entity": "horse",
-            "maxSpawns": 3,
-            "minSpawns": 1,
-            "rarity": 60
-        },
-        {
-            "entity": "llama",
-            "maxSpawns": 3,
-            "minSpawns": 1,
-            "rarity": 65
-        },
-        {
-            "entity": "fox",
-            "maxSpawns": 1,
-            "minSpawns": 1,
-            "rarity": 40
+            "rarity": 10
         },
         {
             "entity": "bee",
-            "maxSpawns": 1,
-            "minSpawns": 1,
+            "maxSpawns": 3,
+            "minSpawns": 2,
             "rarity": 60
         }
     ],

--- a/regions/tundra.json
+++ b/regions/tundra.json
@@ -62,12 +62,6 @@
             "maxSpawns": 2,
             "minSpawns": 1,
             "rarity": 29
-        },
-        {
-            "entity": "polar-bear",
-            "maxSpawns": 2,
-            "minSpawns": 1,
-            "rarity": 20
         }
     ],
     "riverBiomes": [


### PR DESCRIPTION
- Made the temperate entities more balanced
- Goats now only spawn in biomes that can be hilly (birch and plateaus)
- Foxes now only spawn in low forests (oak, combo and long forests)
- Wolves now only spawn in forests (all)
- Llamas no longer spawn. They belong in hills

- Goats now spawn in all mountains
- Llamas now spawn in stoney mountains
- Foxes spawn in forests
- Wolves spawn in almost all of the above
- Polar bears no longer spawn