### PR TITLE
Hot Biome Block Drop Fix

### DIFF
--- a/regions/hot.json
+++ b/regions/hot.json
@@ -110,32 +110,6 @@
             "particleCount": 0
         }
     ],
-    "blockDrops": [{
-        "drops": [
-            {
-                "minAmount": 1,
-                "type": "acacia_planks",
-                "maxAmount": 3
-            },
-            {
-                "type": "stripped_acacia_log",
-                "rarity": 12
-            },
-            {
-                "minAmount": 3,
-                "type": "stick",
-                "maxAmount": 5,
-                "rarity": 7
-            }
-        ],
-        "blocks": [
-            {"block": "minecraft:acacia_wood"},
-            {"block": "minecraft:acacia_log"},
-            {"block": "minecraft:stripped_acacia_wood"},
-            {"block": "minecraft:stripped_acacia_log"}
-        ],
-        "replaceVanillaDrops": true
-    }],
     "objects": [
         {
             "chance": 0,


### PR DESCRIPTION
Removed custom block drops section because it was causing acacia wood trees to not drop anything at all