### PR TITLE
Removes the customDerivitive blocks without IDs in unused biomes

### DIFF
--- a/biomes/temperate/calmplains.json
+++ b/biomes/temperate/calmplains.json
@@ -1,10 +1,5 @@
 {
     "name": "Calm Plains",
-    "customDerivitives": [{
-        "temperature": 0.8,
-        "downfallType": "rain"
-
-        }],
     "derivative": "PLAINS",
     "vanillaDerivative": "PLAINS",
 

--- a/biomes/temperate/fancyplains.json
+++ b/biomes/temperate/fancyplains.json
@@ -1,11 +1,6 @@
 {
     "name": "Fancy Plains",
     "blockDrops": [{"blocks": [{"block": "minecraft:grass_block"}], "drops": [{"type": "bamboo", "minAmount": 1, "maxAmount": 1}], "replaceVanillaDrops": true}],
-    "customDerivitives": [{
-        "temperature": 0.8,
-        "downfallType": "rain"
-
-        }],
     "derivative": "PLAINS",
     "vanillaDerivative": "PLAINS",
     "layers": [{

--- a/biomes/temperate/roughplains.json
+++ b/biomes/temperate/roughplains.json
@@ -1,10 +1,5 @@
 {
     "name": "Rough Plains",
-    "customDerivitives": [{
-        "temperature": 0.8,
-        "downfallType": "rain"
-
-        }],
     "derivative": "PLAINS",
     "vanillaDerivative": "PLAINS",
     "layers": [{

--- a/biomes/temperate/tinybirch.json
+++ b/biomes/temperate/tinybirch.json
@@ -1,10 +1,5 @@
 {
     "name": "Tiny Birch",
-    "customDerivitives": [{
-        "temperature": 0.8,
-        "downfallType": "rain"
-
-        }],
     "derivative": "BIRCH_FOREST",
     "vanillaDerivative": "BIRCH_FOREST",
 

--- a/biomes/temperate/tinyplains.json
+++ b/biomes/temperate/tinyplains.json
@@ -1,13 +1,7 @@
 {
     "name": "Tiny Plains",
-    "customDerivitives": [{
-        "temperature": 0.8,
-        "downfallType": "rain"
-
-        }],
     "derivative": "PLAINS",
     "vanillaDerivative": "PLAINS",
-
     "layers": [{
         "palette": [{"block": "minecraft:grass_block"}],
         "maxHeight": 1,


### PR DESCRIPTION
This resolves the issue in [#1001](https://github.com/VolmitSoftware/Iris/issues/1001)